### PR TITLE
[py2dmat_neighborlist] selfloop

### DIFF
--- a/doc/en/source/tool.rst
+++ b/doc/en/source/tool.rst
@@ -26,11 +26,11 @@ The filename of the generated neighborhood-list file is specified by ``-o`` opti
 
 The following command-line options are available.
 
-- ``-o output``
+- ``-o output`` or ``--output output``
 
   - The filename of output (default: ``neighborlist.txt``)
 
-- ``-u "unit1 unit2..."``
+- ``-u "unit1 unit2..."`` or ``--unit "unit1 unit2..."``
 
   - Length scale for each dimension of coordinate (default: 1.0 for all dims)
 
@@ -40,15 +40,19 @@ The following command-line options are available.
 
   - Each dimension of coordinate is divided by the corresponding ``unit``.
 
-- ``-r radius``
+- ``-r radius`` or ``--radius radius``
 
   - A pair of nodes where the Euclidean distance is less than ``radius`` is considered a neighborhood (default: 1.0)
   - Distances are calculated in the space after coordinates are divided by ``-u``
 
-- ``-q``
+- ``-q`` or ``--quiet``
 
   - Do not show a progress bar
   - Showing a progress bar requires ``tqdm`` python package
+
+- ``--allow-selfloop``
+
+  - Include :math:`i` in the neighborhoods of :math:`i` itself
 
 - ``--check-allpairs``
 

--- a/doc/ja/source/tool.rst
+++ b/doc/ja/source/tool.rst
@@ -26,11 +26,11 @@
 
 次のようなオプションが利用できます。
 
-- ``-o output``
+- ``-o output`` or ``--output output``
 
   - 出力ファイル名 (default: ``neighborlist.txt``)
 
-- ``-u "unit1 unit2..."``
+- ``-u "unit1 unit2..."`` or ``--unit "unit1 unit2"``
 
   - 各次元の長さスケール (default: すべて 1.0)
 
@@ -38,15 +38,19 @@
 
   - 各座標はあらかじめこれらの長さスケールで除算されます
 
-- ``-r radius``
+- ``-r radius`` or ``--radius radius``
 
   - 近傍とみなされるユークリッド距離 (default: 1.0)
   - 距離は ``-u`` で除されたあとの座標に対して計算されます
 
-- ``-q``
+- ``-q`` or ``--quiet``
 
   - 進捗バーを表示しません
   - なお、進捗バーの表示には ``tqdm`` python パッケージが必要です
+
+- ``--allow-selfloop``
+
+  - 自分自身を隣接リストに含めます（自己ループ）
 
 - ``--check-allpairs``
 

--- a/tests/exchange_mesh/ref.txt
+++ b/tests/exchange_mesh/ref.txt
@@ -1,7 +1,7 @@
 nprocs = 4
 rank = 0
-step = 2720
-walker = 2
+step = 1311
+walker = 0
 fx = 0.0
 x1 = 1.0
 x2 = 1.0


### PR DESCRIPTION
The original version of `py2dmat_neighborlist` allows self-loops ( `i->i` ) but it with the `--check-allpairs` option does not. This PR fixes this mismatch by avoiding self-loops.
Additionally, a new option ``--allow-selfloop`` allows self-loops.