### PR TITLE
migrate from toml to tomli

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
           python -m pip install -U pip
           python -m pip install setuptools wheel
           python -m pip install Cython
-          python -m pip install numpy scipy toml mpi4py
+          python -m pip install numpy scipy tomli mpi4py
           python -m pip install physbo
 
       - name: ${{ matrix.algorithm }}

--- a/README.md
+++ b/README.md
@@ -7,19 +7,10 @@ The optimal parameters are estimated by minimizing the loss function using a sea
 In the current version, for solving a direct problem, 2DMAT offers the wrapper of the solver for the total-reflection high-energy positron diffraction (TRHEPD) experiment.
 As algorithms, it offers the Nelder-Mead method, the grid search method, the Bayesian optimization method, and the replica exchange Monte Carlo method. In the future, we plan to add other direct problem solvers and search algorithms in 2DMAT.
 
-| Branch | Build status | Documentation |
-| :-: | :-: | :-: |
-| master | [![master][CI/master/badge]][CI/master/uri] | [![doc_en][doc/en/badge]][doc/en/uri] [![doc_ja][doc/ja/badge]][doc/ja/uri] |
-| v1.0.1 | -- | [![doc_en][doc/en/badge]][doc/stable/en/uri] [![doc_ja][doc/ja/badge]][doc/stable/ja/uri] |
-
-[CI/master/badge]:https://github.com/issp-center-dev/2DMAT/workflows/Test/badge.svg?branch=master
-[CI/master/uri]:https://github.com/issp-center-dev/2DMAT/actions?query=branch%3Amaster
-[doc/en/badge]:https://img.shields.io/badge/doc-English-blue.svg
-[doc/en/uri]:https://issp-center-dev.github.io/2DMAT/manual/master/en/index.html
-[doc/ja/badge]:https://img.shields.io/badge/doc-Japanese-blue.svg
-[doc/ja/uri]:https://issp-center-dev.github.io/2DMAT/manual/master/ja/index.html
-[doc/stable/en/uri]:https://issp-center-dev.github.io/2DMAT/manual/v1.0.1/en/index.html
-[doc/stable/ja/uri]:https://issp-center-dev.github.io/2DMAT/manual/v1.0.1/ja/index.html
+| Branch |                Build status                 |                                       Documentation                                       |
+| :----: | :-----------------------------------------: | :---------------------------------------------------------------------------------------: |
+| master | [![master][ci/master/badge]][ci/master/uri] |        [![doc_en][doc/en/badge]][doc/en/uri] [![doc_ja][doc/ja/badge]][doc/ja/uri]        |
+| v1.0.1 |                     --                      | [![doc_en][doc/en/badge]][doc/stable/en/uri] [![doc_ja][doc/ja/badge]][doc/stable/ja/uri] |
 
 ## py2dmat
 
@@ -32,7 +23,7 @@ and solvers (`py2dmat` also means this script).
 - Required
   - python >= 3.6
   - numpy >= 1.14
-  - toml
+  - tomli >= 1.0.0
 - Optional
   - scipy
     - for `minsearch` algorithm
@@ -49,7 +40,7 @@ and solvers (`py2dmat` also means this script).
     - [`pipx`](https://pipxproject.github.io/pipx/) may help you from the dependency hell :p
 - From Source (For developers)
   1. update `pip >= 19` by `python3 -m pip install -U pip`
-  2. `python3 -m pip install 2DMAT_ROOT_DIRECTORY` to install `py2dmat` package and `py2dmat` command
+  1. `python3 -m pip install 2DMAT_ROOT_DIRECTORY` to install `py2dmat` package and `py2dmat` command
 
 ### Simple Usage
 
@@ -64,4 +55,13 @@ This package is distributed under GNU General Public License version 3 (GPL v3) 
 ## Copyright
 
 © *2020- The University of Tokyo. All rights reserved.*
-This software was developed with the support of \"*Project for advancement of software usability in materials science*\" of The Institute for Solid State Physics, The University of Tokyo. 
+This software was developed with the support of "*Project for advancement of software usability in materials science*" of The Institute for Solid State Physics, The University of Tokyo.
+
+[ci/master/badge]: https://github.com/issp-center-dev/2DMAT/workflows/Test/badge.svg?branch=master
+[ci/master/uri]: https://github.com/issp-center-dev/2DMAT/actions?query=branch%3Amaster
+[doc/en/badge]: https://img.shields.io/badge/doc-English-blue.svg
+[doc/en/uri]: https://issp-center-dev.github.io/2DMAT/manual/master/en/index.html
+[doc/ja/badge]: https://img.shields.io/badge/doc-Japanese-blue.svg
+[doc/ja/uri]: https://issp-center-dev.github.io/2DMAT/manual/master/ja/index.html
+[doc/stable/en/uri]: https://issp-center-dev.github.io/2DMAT/manual/v1.0.1/en/index.html
+[doc/stable/ja/uri]: https://issp-center-dev.github.io/2DMAT/manual/v1.0.1/ja/index.html

--- a/doc/en/source/customize/usage.rst
+++ b/doc/en/source/customize/usage.rst
@@ -19,10 +19,12 @@ The number of flow corresponds the comment in the program example.
 4. Invoke ``algorithm.main()``
 
 
-Example::
+Example
+
+.. code-block:: python
 
     import sys
-    import toml
+    import tomli
     import py2dmat
 
     # (1)
@@ -35,10 +37,10 @@ Example::
         ...
     
 
-    file_name = sys.argv[1]
-
     # (2)
-    info = py2dmat.Info(toml.load(file_name))
+    with open(sys.argv[1]) as f:
+        inp = tomli.load(f)
+    info = py2dmat.Info(inp)
 
     # (3)
     solver = Solver(info)

--- a/doc/en/source/start.rst
+++ b/doc/en/source/start.rst
@@ -6,7 +6,7 @@ Prerequisites
 - Python3 (>=3.6)
 
     - The following Python packages are required.
-        - toml
+        - tomli
         - numpy >= 1.14
 
     - Optional packages

--- a/doc/ja/source/customize/usage.rst
+++ b/doc/ja/source/customize/usage.rst
@@ -17,10 +17,12 @@
 4. ``algorithm.main()`` を実行する
 
 
-プログラム例 ::
+プログラム例 
+
+.. code-block:: python
 
     import sys
-    import toml
+    import tomli
     import py2dmat
 
     # (1)
@@ -31,12 +33,11 @@
     class Algorithm(py2dmat.algorithm.AlgorithmBase):
         # Define your algorithm
         pass
-    
-
-    file_name = sys.argv[1]
 
     # (2)
-    info = py2dmat.Info(toml.load(file_name))
+    with open(sys.argv[1]) as f:
+        inp = tomli.load(f)
+    info = py2dmat.Info(inp)
 
     # (3)
     solver = Solver(info)

--- a/doc/ja/source/start.rst
+++ b/doc/ja/source/start.rst
@@ -7,7 +7,7 @@ py2dmat のインストール
 
     - 必要なpythonパッケージ
 
-        - toml
+        - tomli
         - numpy (>= 1.14)
 
     - Optional なパッケージ

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.6"
 numpy = "^1.14"
-toml = ">= 0.10.0"
+tomli = "^1"
 scipy = {version = "^1", optional = true}
 mpi4py = {version = "^3", optional = true}
 physbo = {version = ">= 0.3.0", optional = true}

--- a/src/py2dmat/_main.py
+++ b/src/py2dmat/_main.py
@@ -1,9 +1,24 @@
-from sys import exit, argv
-
-import toml
+from sys import exit
 
 import py2dmat
 import py2dmat.mpi
+
+try:
+    from tomli import load as toml_load
+except ImportError:
+    try:
+        from toml import load as toml_load
+        if py2dmat.mpi.rank() == 0:
+            print("WARNING: tomli is not found and toml is found.")
+            print("         use of toml package is left for compatibility.")
+            print("         please install tomli package.")
+            print("HINT: python3 -m pip install tomli")
+            print()
+    except ImportError:
+        if py2dmat.mpi.rank() == 0:
+            print("ERROR: tomli is not found")
+            print("HINT: python3 -m pip install tomli")
+        exit(1)
 
 
 def main():
@@ -23,7 +38,8 @@ def main():
     file_name = args.inputfile
     inp = {}
     if py2dmat.mpi.rank() == 0:
-        inp = toml.load(file_name)
+        with open(file_name) as f:
+            inp = toml_load(f)
     if py2dmat.mpi.size() > 1:
         inp = py2dmat.mpi.comm().bcast(inp, root=0)
     info = py2dmat.Info(inp)


### PR DESCRIPTION
Now `py2dmat` and `py2dmat_main.py` use [toml](https://pypi.org/project/toml/) package for parsing TOML files. However, this package is a little outdated (`toml` is compatible with TOML v0.5.0, but TOML v1.0.0 has already appeared) and not active, unfortunately.
For example, TOML v1.0.0 allows a heterogeneous array (e.g., `[1, 0.0]`), but `toml` does not (raises an error).

After this PR, we use another TOML parser package, [tomli](https://pypi.org/project/tomli/). This package is up-to-date (compatible with TOML v1.0.0) and active (the latest version was released 3 days ago!).

When `tomli` is not found, `toml` will be used with a warning message for backward compatibility.