### PR TITLE
`load` of tomli v2 requires BinaryIO instead of TextIO

### DIFF
--- a/src/py2dmat/_main.py
+++ b/src/py2dmat/_main.py
@@ -2,23 +2,24 @@ from sys import exit
 
 import py2dmat
 import py2dmat.mpi
+import py2dmat.util.toml
 
-try:
-    from tomli import load as toml_load
-except ImportError:
-    try:
-        from toml import load as toml_load
-        if py2dmat.mpi.rank() == 0:
-            print("WARNING: tomli is not found and toml is found.")
-            print("         use of toml package is left for compatibility.")
-            print("         please install tomli package.")
-            print("HINT: python3 -m pip install tomli")
-            print()
-    except ImportError:
-        if py2dmat.mpi.rank() == 0:
-            print("ERROR: tomli is not found")
-            print("HINT: python3 -m pip install tomli")
-        exit(1)
+# try:
+#     from tomli import load as toml_load
+# except ImportError:
+#     try:
+#         from toml import load as toml_load
+#         if py2dmat.mpi.rank() == 0:
+#             print("WARNING: tomli is not found and toml is found.")
+#             print("         use of toml package is left for compatibility.")
+#             print("         please install tomli package.")
+#             print("HINT: python3 -m pip install tomli")
+#             print()
+#     except ImportError:
+#         if py2dmat.mpi.rank() == 0:
+#             print("ERROR: tomli is not found")
+#             print("HINT: python3 -m pip install tomli")
+#         exit(1)
 
 
 def main():
@@ -38,8 +39,9 @@ def main():
     file_name = args.inputfile
     inp = {}
     if py2dmat.mpi.rank() == 0:
-        with open(file_name) as f:
-            inp = toml_load(f)
+        inp = py2dmat.util.toml.load(file_name)
+        # with open(file_name) as f:
+        #     inp = toml_load(f)
     if py2dmat.mpi.size() > 1:
         inp = py2dmat.mpi.comm().bcast(inp, root=0)
     info = py2dmat.Info(inp)

--- a/src/py2dmat/util/toml.py
+++ b/src/py2dmat/util/toml.py
@@ -1,0 +1,55 @@
+from typing import MutableMapping, Any
+
+from ..mpi import rank
+
+USE_TOML = False
+TOMLI_VERSION = 2
+
+try:
+    import tomli
+
+    if tomli.__version__ < "2.0.0":
+        TOMLI_VERSION = 1
+    else:
+        TOMLI_VERSION = 2
+except ImportError:
+    try:
+        import toml
+
+        USE_TOML = True
+        if rank() == 0:
+            print("WARNING: tomli is not found and toml is found.")
+            print("         use of toml package is left for compatibility.")
+            print("         please install tomli package.")
+            print("HINT: python3 -m pip install tomli")
+            print()
+    except ImportError:
+        if rank() == 0:
+            print("ERROR: tomli is not found")
+            print("HINT: python3 -m pip install tomli")
+        raise
+
+
+def load(path: str) -> MutableMapping[str, Any]:
+    """read TOML file
+
+    Parameters
+    ----------
+    path: str
+        File path to an input TOML file
+
+    Returns
+    -------
+    toml_dict: MutableMapping[str, Any]
+        Dictionary representing TOML file
+
+    """
+    if USE_TOML:
+        return toml.load(path)
+    else:
+        if TOMLI_VERSION == 1:
+            with open(path, "r") as f:
+                return tomli.load(f)
+        else:
+            with open(path, "rb") as f:
+                return tomli.load(f)


### PR DESCRIPTION
A new function, `py2dmat.util.toml.load(path : str) -> dict` wraps `toml.load` and `tomli.load` (v1 and v2).